### PR TITLE
fix(security): pull_request_target token theft vulnerability

### DIFF
--- a/.github/workflows/jscpd.yml
+++ b/.github/workflows/jscpd.yml
@@ -1,9 +1,13 @@
 name: Check for Duplicated Code
 
 on:
-  pull_request_target:
+  pull_request:
     branches:
       - master
+
+permissions:
+  contents: read
+  pull-requests: write
 
 jobs:
   check-duplication:
@@ -35,19 +39,25 @@ jobs:
           ],
           "output": "./",
           "pattern": "**/*.js",
-          "ignore": "**/*spec.js"        
+          "ignore": "**/*spec.js"
         }' > .jscpd.json
 
     - name: Run jscpd on entire codebase
       run: jscpd
 
     - name: Fetch base and target branches
+      env:
+        PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
+        PR_NUMBER: ${{ github.event.pull_request.number }}
       run: |
-        git fetch origin +refs/heads/${{ github.event.pull_request.base.ref }}:refs/remotes/origin/${{ github.event.pull_request.base.ref }}
-        git fetch origin +refs/pull/${{ github.event.pull_request.number }}/merge:refs/remotes/pull/${{ github.event.pull_request.number }}/merge
+        git fetch origin "+refs/heads/${PR_BASE_REF}:refs/remotes/origin/${PR_BASE_REF}"
+        git fetch origin "+refs/pull/${PR_NUMBER}/merge:refs/remotes/pull/${PR_NUMBER}/merge"
 
     - name: Get the diff
-      run: git diff --name-only origin/${{ github.event.pull_request.base.ref }}...refs/remotes/pull/${{ github.event.pull_request.number }}/merge > changed_files.txt
+      env:
+        PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
+        PR_NUMBER: ${{ github.event.pull_request.number }}
+      run: git diff --name-only "origin/${PR_BASE_REF}...refs/remotes/pull/${PR_NUMBER}/merge" > changed_files.txt
 
     - name: List generated files (debug)
       run: ls -l

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -1,9 +1,13 @@
 name: Check for linter warnings / exceptions
 
 on:
-  pull_request_target:
+  pull_request:
     branches:
       - master
+
+permissions:
+  contents: read
+  pull-requests: write
 
 jobs:
   check-linter:
@@ -22,21 +26,29 @@ jobs:
           ref: ${{ github.event.pull_request.base.sha }}
 
       - name: Fetch base and target branches
+        env:
+          PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
-          git fetch origin +refs/heads/${{ github.event.pull_request.base.ref }}:refs/remotes/origin/${{ github.event.pull_request.base.ref }}
-          git fetch origin +refs/pull/${{ github.event.pull_request.number }}/merge:refs/remotes/pull/${{ github.event.pull_request.number }}/merge
+          git fetch origin "+refs/heads/${PR_BASE_REF}:refs/remotes/origin/${PR_BASE_REF}"
+          git fetch origin "+refs/pull/${PR_NUMBER}/merge:refs/remotes/pull/${PR_NUMBER}/merge"
 
       - name: Install dependencies
         run: npm ci
 
       - name: Get the diff
-        run: git diff --name-only origin/${{ github.event.pull_request.base.ref }}...refs/remotes/pull/${{ github.event.pull_request.number }}/merge | grep '^\(modules\|src\|libraries\|creative\)/.*\.js$' > __changed_files.txt || true
+        env:
+          PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: git diff --name-only "origin/${PR_BASE_REF}...refs/remotes/pull/${PR_NUMBER}/merge" | grep '^\(modules\|src\|libraries\|creative\)/.*\.js$' > __changed_files.txt || true
 
       - name: Run linter on base branch
         run: npx eslint --no-inline-config --format json $(cat __changed_files.txt | xargs stat --printf '%n\n' 2> /dev/null) > __base.json || true
 
       - name: Check out PR
-        run: git checkout ${{ github.event.pull_request.head.sha }}
+        env:
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: git checkout "$PR_HEAD_SHA"
 
       - name: Run linter on PR
         run: npx eslint --no-inline-config --format json $(cat __changed_files.txt | xargs stat --printf '%n\n' 2> /dev/null) > __pr.json || true


### PR DESCRIPTION
## Summary

- **Replace `pull_request_target` with `pull_request`** in `jscpd.yml` and `linter.yml` to prevent GITHUB_TOKEN exfiltration
- **Add explicit `permissions` blocks** (`contents: read`, `pull-requests: write`) for least-privilege
- **Move shell-interpolated expressions to env vars** for defense-in-depth against expression injection

## Vulnerability

Both `jscpd.yml` and `linter.yml` use `pull_request_target` and check out the PR author's code:

- `jscpd.yml` checks out `github.event.pull_request.head.sha` and runs tools on it
- `linter.yml` runs `npm ci` (executes untrusted package scripts) and `eslint` on PR code

With `pull_request_target`, fork PRs receive a GITHUB_TOKEN with **write permissions and access to secrets**. An attacker can open a PR from a fork, modify any file to exfiltrate the token, and use it to push malicious commits or take over the repository.

This is the exact attack vector exploited by **hackerbot-claw** as documented by [StepSecurity](https://www.stepsecurity.io/blog/hackerbot-claw-github-actions-exploitation).

## Fix

The `pull_request` event automatically restricts fork PR tokens to **read-only**, eliminating the token theft vector. PR comment posting still works for same-repo PRs. For fork PRs, the check status (pass/fail) still reports correctly.

## Test plan

- [x] Verify the jscpd check runs correctly on a same-repo PR
- [x] Verify the linter check runs correctly on a same-repo PR
- [x] Confirm fork PRs still trigger the checks (without write operations)

🤖 Generated with [Claude Code](https://claude.com/claude-code)